### PR TITLE
Create tRPC Profiles router

### DIFF
--- a/server/api/root.ts
+++ b/server/api/root.ts
@@ -5,6 +5,7 @@
 
 import { createCallerFactory, createTRPCRouter } from "@/server/api/trpc";
 import { exampleApiRouter } from "./routers/example";
+import { profilesApiRouter } from "./routers/profiles";
 
 // [NOTE]
 // To expose a new API, add a new router here.
@@ -12,6 +13,7 @@ import { exampleApiRouter } from "./routers/example";
 /** Primary router for the API server. */
 export const appRouter = createTRPCRouter({
   example: exampleApiRouter,
+  profiles: profilesApiRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/server/api/routers/profiles.ts
+++ b/server/api/routers/profiles.ts
@@ -1,0 +1,80 @@
+import z from "zod";
+import { eq, asc } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { db } from "@/server/db";
+import { profiles } from "@/server/db/schema";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+const ProfileSchema = z.object({
+  id: z.string(),
+  role: z.enum(["admin", "student"]),
+  full_name: z.string(),
+  is_active: z.boolean(),
+});
+
+async function fetchProfile(userId: string) {
+  const [row] = await db.select().from(profiles).where(eq(profiles.id, userId));
+  if (!row) throw new TRPCError({ code: "NOT_FOUND" });
+  return row;
+}
+
+async function requireAdmin(userId: string) {
+  const profile = await fetchProfile(userId);
+  if (profile.role !== "admin") throw new TRPCError({ code: "FORBIDDEN" });
+  return profile;
+}
+
+const me = protectedProcedure.output(ProfileSchema).query(async ({ ctx }) => {
+  return fetchProfile(ctx.subject.id);
+});
+
+const updateMe = protectedProcedure
+  .input(
+    z.object({
+      full_name: z.string().optional(),
+      is_active: z.boolean().optional(),
+    }),
+  )
+  .output(ProfileSchema)
+  .mutation(async ({ ctx, input }) => {
+    const [updated] = await db
+      .update(profiles)
+      .set(input)
+      .where(eq(profiles.id, ctx.subject.id))
+      .returning();
+    if (!updated) throw new TRPCError({ code: "NOT_FOUND" });
+    return updated;
+  });
+
+const getById = protectedProcedure
+  .input(z.object({ userId: z.string() }))
+  .output(ProfileSchema)
+  .query(async ({ ctx, input }) => {
+    await requireAdmin(ctx.subject.id);
+    const [row] = await db
+      .select()
+      .from(profiles)
+      .where(eq(profiles.id, input.userId));
+    if (!row) throw new TRPCError({ code: "NOT_FOUND" });
+    return row;
+  });
+
+const list = protectedProcedure
+  .input(z.object({ isActive: z.boolean().optional() }).optional())
+  .output(z.array(ProfileSchema))
+  .query(async ({ ctx, input }) => {
+    await requireAdmin(ctx.subject.id);
+    const baseQuery = db.select().from(profiles);
+    const filtered =
+      input?.isActive !== undefined
+        ? baseQuery.where(eq(profiles.is_active, input.isActive))
+        : baseQuery;
+    return filtered.orderBy(asc(profiles.full_name), asc(profiles.id));
+  });
+
+export const profilesApiRouter = createTRPCRouter({
+  me,
+  updateMe,
+  getById,
+  list,
+});

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -6,11 +6,11 @@
  * npx drizzle-kit push
  * ```
  */
-import { pgTable, text, boolean } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, boolean } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 
 export const profiles = pgTable("profiles", {
-  id: text("id").primaryKey(),
+  id: uuid("id").primaryKey(),
   role: text("role", { enum: ["admin", "student"] }).notNull(),
   full_name: text("full_name").notNull(),
   is_active: boolean("is_active").notNull(),

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -6,7 +6,12 @@
  * npx drizzle-kit push
  * ```
  */
-import { pgTable, text } from "drizzle-orm/pg-core";
+import { pgTable, text, boolean } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 
-export {};
+export const profiles = pgTable("profiles", {
+  id: text("id").primaryKey(),
+  role: text("role", { enum: ["admin", "student"] }).notNull(),
+  full_name: text("full_name").notNull(),
+  is_active: boolean("is_active").notNull(),
+});


### PR DESCRIPTION
Created tRPC profiles router to support reading/updating user profile data with the following endpoints:

- `profiles.me()` returns the authenticated user's own profile
- `profiles.updateMe()` updates the authenticated user's full_name and/or is_active
- `profiles.getById()` returns any profile by userId (admin only)
- `profiles.list()` returns all profiles with optional isActive filter (admin only)

Defined profiles table in schema per requirements in #2

Closes #10