### PR TITLE
Issue #33 Admin Select Cohort Page

### DIFF
--- a/components/CohortRow.tsx
+++ b/components/CohortRow.tsx
@@ -1,0 +1,173 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { Trash2 } from "lucide-react";
+import { api } from "@/utils/trpc/api";
+
+type CohortRowProps = {
+  id: number;
+  name: string | null;
+  slug: string | null;
+  is_active: boolean | null;
+  member_count: number;
+  recent_logins: number;
+  onDeleted: () => void;
+  onToggled: () => void;
+};
+
+export default function CohortRow({
+  id,
+  name,
+  slug,
+  is_active,
+  member_count: _member_count,
+  recent_logins,
+  onDeleted,
+  onToggled,
+}: CohortRowProps) {
+  const router = useRouter();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const setActive = api.cohorts.setActiveStatus.useMutation({
+    onSuccess: onToggled,
+  });
+
+  const deleteCohort = api.cohorts.deleteCohort.useMutation({
+    onSuccess: () => {
+      setShowDeleteDialog(false);
+      onDeleted();
+    },
+  });
+
+  const handleRowClick = () => {
+    if (is_active && slug) {
+      router.push(`/cohorts/${slug}/dashboard`);
+    }
+  };
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setActive.mutate({ id, is_active: !is_active });
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowDeleteDialog(true);
+  };
+
+  const handleConfirmDelete = () => {
+    deleteCohort.mutate({ id });
+  };
+
+  const displayName = name ?? slug ?? `Cohort ${id}`;
+
+  return (
+    <>
+      <div
+        className={`flex items-center justify-between border-b border-gray-200 px-6 py-4 ${
+          is_active ? "cursor-pointer hover:bg-gray-50" : ""
+        }`}
+        onClick={handleRowClick}
+      >
+        {/* Left: cohort name */}
+        <span
+          className={`text-base font-medium ${
+            is_active
+              ? "border-b border-gray-700 text-gray-900"
+              : "text-gray-400"
+          }`}
+        >
+          {displayName}
+        </span>
+
+        {/* Right: stats + status + toggle + delete */}
+        <div
+          className="flex items-center gap-4"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* View count */}
+          <span className="text-sm text-gray-500">
+            {recent_logins} viewed in last 14 days
+          </span>
+
+          {/* Active / Inactive indicator */}
+          {is_active ? (
+            <span className="flex items-center gap-1 text-sm font-medium text-green-600">
+              <span className="h-2 w-2 rounded-full bg-green-500" />
+              Active
+            </span>
+          ) : (
+            <span className="text-sm font-medium text-gray-400">Inactive</span>
+          )}
+
+          {/* Toggle switch */}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={!!is_active}
+            onClick={handleToggle}
+            disabled={setActive.isPending}
+            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none disabled:opacity-50 ${
+              is_active ? "bg-green-500" : "bg-gray-300"
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200 ease-in-out ${
+                is_active ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+
+          {/* Delete button */}
+          <button
+            type="button"
+            onClick={handleDeleteClick}
+            className="text-gray-400 transition-colors hover:text-gray-700"
+            aria-label="Delete cohort"
+          >
+            <Trash2 size={18} />
+          </button>
+        </div>
+      </div>
+
+      {/* Delete confirmation dialog */}
+      {showDeleteDialog && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => setShowDeleteDialog(false)}
+        >
+          <div
+            className="mx-4 w-full max-w-sm rounded-xl bg-white p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-2 text-lg font-semibold text-gray-900">
+              Delete cohort?
+            </h2>
+            <p className="mb-6 text-sm text-gray-500">
+              Are you sure you want to delete{" "}
+              <span className="font-medium text-gray-800">{displayName}</span>?
+              This action cannot be undone and will remove all members and
+              content associated with this cohort.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDeleteDialog(false)}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmDelete}
+                disabled={deleteCohort.isPending}
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteCohort.isPending ? "Deleting..." : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/pages/admin/cohorts.tsx
+++ b/pages/admin/cohorts.tsx
@@ -1,0 +1,56 @@
+import { useRouter } from "next/router";
+import { api } from "@/utils/trpc/api";
+import CohortRow from "@/components/CohortRow";
+
+export default function AdminCohortsPage() {
+  const router = useRouter();
+  const { data: cohorts, isLoading, refetch } = api.cohorts.getAllCohorts.useQuery();
+
+  const handleCreateCohort = () => {
+    router.push("/admin/cohorts/new");
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center bg-white px-4 py-12">
+      <h1 className="mb-10 text-3xl font-semibold text-gray-900">
+        Select a cohort
+      </h1>
+
+      <div className="w-full max-w-3xl rounded-lg border border-gray-200 bg-white shadow-sm">
+        {isLoading ? (
+          <div className="px-6 py-8 text-center text-sm text-gray-400">
+            Loading cohorts...
+          </div>
+        ) : !cohorts || cohorts.length === 0 ? (
+          <div className="px-6 py-8 text-center text-sm text-gray-400">
+            No cohorts found.
+          </div>
+        ) : (
+          cohorts.map((cohort) => (
+            <CohortRow
+              key={cohort.id}
+              id={cohort.id}
+              name={cohort.name}
+              slug={cohort.slug}
+              is_active={cohort.is_active}
+              member_count={cohort.member_count}
+              recent_logins={cohort.recent_logins}
+              onDeleted={() => refetch()}
+              onToggled={() => refetch()}
+            />
+          ))
+        )}
+
+        <div className="flex justify-center px-6 py-6">
+          <button
+            type="button"
+            onClick={handleCreateCohort}
+            className="w-80 rounded-full bg-gray-200 px-8 py-3 text-base font-medium text-gray-700 transition-colors hover:bg-gray-300"
+          >
+            Create New Cohort
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/api/routers/cohorts.ts
+++ b/server/api/routers/cohorts.ts
@@ -1,0 +1,243 @@
+import { z } from "zod";
+import { eq, and, count, sql } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { db } from "@/server/db";
+import {
+  cohorts,
+  cohort_memberships,
+  profiles,
+  resources,
+  discussions_post,
+} from "@/server/db/schema";
+import {
+  createTRPCRouter,
+  publicProcedure,
+  protectedProcedure,
+} from "../trpc";
+
+const CohortSchema = z.object({
+  id: z.number(),
+  is_active: z.boolean().nullable(),
+  access_hash: z.string(),
+  slug: z.string().nullable(),
+});
+
+const CohortWithStatsSchema = z.object({
+  id: z.number(),
+  name: z.string().nullable(),
+  slug: z.string().nullable(),
+  is_active: z.boolean().nullable(),
+  member_count: z.number(),
+  recent_logins: z.number(),
+});
+
+async function requireAdmin(userId: string) {
+  const profile = await db.query.profiles.findFirst({
+    where: eq(profiles.id, userId),
+  });
+  if (!profile || profile.role !== "admin") {
+    throw new TRPCError({ code: "FORBIDDEN" });
+  }
+}
+
+export const cohortsApiRouter = createTRPCRouter({
+  hasCohortMembership: publicProcedure
+    .input(z.object({ userId: z.string().uuid().optional() }))
+    .output(CohortSchema.nullable())
+    .query(async ({ ctx, input }) => {
+      if (!ctx.subject) {
+        console.log("No ctx.subject, returning null");
+        return null;
+      }
+
+      const userId = input.userId || ctx.subject.id;
+      if (ctx.subject.id !== userId) {
+        throw new TRPCError({ code: "UNAUTHORIZED" });
+      }
+
+      const membership = await db.query.cohort_memberships.findFirst({
+        where: eq(cohort_memberships.profiles_id, userId),
+      });
+
+      if (!membership?.cohort_id) {
+        console.log("No membership, returning null");
+        return null;
+      }
+
+      const cohort = await db.query.cohorts.findFirst({
+        where: and(
+          eq(cohorts.id, membership.cohort_id),
+          eq(cohorts.is_active, true),
+        ),
+      });
+
+      if (!cohort || !cohort.slug) {
+        console.log("Cohort not valid, returning null");
+        return null;
+      }
+
+      return CohortSchema.parse(cohort);
+    }),
+
+  joinCohort: protectedProcedure
+    .input(
+      z.object({
+        accessHash: z.string().min(1),
+        userId: z.string().uuid(),
+      }),
+    )
+    .output(CohortSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { accessHash, userId } = input;
+
+      const cohort = await db.query.cohorts.findFirst({
+        where: eq(cohorts.access_hash, accessHash),
+      });
+
+      if (!cohort) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invalid access code",
+        });
+      }
+
+      if (cohort.is_active !== true) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Cohort is not active",
+        });
+      }
+
+      if (!cohort.slug) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Cohort is not properly configured",
+        });
+      }
+
+      const userProfile = await db.query.profiles.findFirst({
+        where: eq(profiles.id, userId),
+      });
+
+      if (!userProfile) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "User profile not found",
+        });
+      }
+
+      const existingMembership = await db.query.cohort_memberships.findFirst({
+        where: eq(cohort_memberships.profiles_id, userId),
+      });
+
+      if (userProfile.role === "student" && existingMembership) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Students can only belong to one cohort",
+        });
+      }
+
+      const existingMembershipForCohort =
+        await db.query.cohort_memberships.findFirst({
+          where: and(
+            eq(cohort_memberships.profiles_id, userId),
+            eq(cohort_memberships.cohort_id, cohort.id),
+          ),
+        });
+
+      if (existingMembershipForCohort) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "User is already a member of this cohort",
+        });
+      }
+
+      await db.insert(cohort_memberships).values({
+        profiles_id: userId,
+        cohort_id: cohort.id,
+      });
+
+      return CohortSchema.parse(cohort);
+    }),
+
+  getAllCohorts: protectedProcedure
+    .output(z.array(CohortWithStatsSchema))
+    .query(async ({ ctx }) => {
+      await requireAdmin(ctx.subject.id);
+
+      const allCohorts = await db.select().from(cohorts);
+
+      const results = await Promise.all(
+        allCohorts.map(async (cohort) => {
+          const [memberCountRow] = await db
+            .select({ count: count() })
+            .from(cohort_memberships)
+            .innerJoin(profiles, eq(profiles.id, cohort_memberships.profiles_id))
+            .where(
+              and(
+                eq(cohort_memberships.cohort_id, cohort.id),
+                eq(profiles.role, "student"),
+              ),
+            );
+
+          // Query auth.users via raw SQL to get last_sign_in_at
+          const recentLoginsResult = await db.execute(sql`
+            SELECT COUNT(DISTINCT cm.profiles_id)::int AS recent_count
+            FROM cohort_memberships cm
+            JOIN profiles p ON p.id = cm.profiles_id
+            JOIN auth.users u ON u.id = cm.profiles_id
+            WHERE cm.cohort_id = ${cohort.id}
+              AND p.role = 'student'
+              AND u.last_sign_in_at > NOW() - INTERVAL '14 days'
+          `);
+
+          const recentLogins =
+            (recentLoginsResult[0] as { recent_count: number } | undefined)
+              ?.recent_count ?? 0;
+
+          return {
+            id: cohort.id,
+            name: cohort.name ?? null,
+            slug: cohort.slug ?? null,
+            is_active: cohort.is_active ?? null,
+            member_count: memberCountRow?.count ?? 0,
+            recent_logins: recentLogins,
+          };
+        }),
+      );
+
+      return results;
+    }),
+
+  setActiveStatus: protectedProcedure
+    .input(z.object({ id: z.number(), is_active: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      await requireAdmin(ctx.subject.id);
+
+      await db
+        .update(cohorts)
+        .set({ is_active: input.is_active })
+        .where(eq(cohorts.id, input.id));
+    }),
+
+  deleteCohort: protectedProcedure
+    .input(z.object({ id: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      await requireAdmin(ctx.subject.id);
+
+      // Delete dependent rows first
+      await db
+        .delete(discussions_post)
+        .where(eq(discussions_post.cohort_id, input.id));
+
+      await db
+        .delete(resources)
+        .where(eq(resources.cohort_id, input.id));
+
+      await db
+        .delete(cohort_memberships)
+        .where(eq(cohort_memberships.cohort_id, input.id));
+
+      await db.delete(cohorts).where(eq(cohorts.id, input.id));
+    }),
+});

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -7,9 +7,86 @@
  * ```
  */
 import {
+  uuid,
+  check,
+  integer,
   pgTable,
+  serial,
   text,
+  timestamp,
+  boolean,
+  varchar,
+  pgEnum,
+  primaryKey,
+  pgSchema,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
+import { config } from "dotenv";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { AnyPgColumn } from "drizzle-orm/pg-core";
 
-export {}
+export const profiles = pgTable("profiles", {
+  id: uuid("id").primaryKey(),
+  role: text("role", { enum: ["admin", "student"] }).notNull(),
+  full_name: text("full_name").notNull(),
+  is_active: boolean("is_active").notNull(),
+  email: text("email"),
+  jobRole: text("job_role"),
+  organization: text("organization"),
+  avatarUrl: text("avatar_url"),
+});
+
+export const cohorts = pgTable("cohorts", {
+  id: serial("id").primaryKey(),
+  name: text("name"),
+  is_active: boolean("is_active"),
+  access_hash: text("access_hash").notNull(),
+  slug: varchar("slug"),
+});
+
+export const cohort_memberships = pgTable("cohort_memberships", {
+  cohort_id: integer("cohort_id").references(() => cohorts.id),
+  profiles_id: uuid("profiles_id").references(() => profiles.id),
+});
+
+export const modules = pgTable("modules", {
+  id: serial("id").primaryKey(),
+  module_index: integer("module_index").notNull().unique(),
+  slug: varchar("slug").notNull().unique(),
+  title: text("title").notNull(),
+  description: text("description"),
+  is_locked: boolean("is_locked"),
+});
+
+export const resourceTypeEnum = pgEnum("resource_type", [
+  "handout",
+  "recording",
+  "link",
+]);
+
+export const resources = pgTable("resources", {
+  id: serial("id").primaryKey(),
+  module_id: integer("module_id").references(() => modules.id),
+  cohort_id: integer("cohort_id").references(() => cohorts.id),
+  type: resourceTypeEnum("type").notNull(),
+  title: text("title").notNull(),
+  description: text("description"),
+  url: text("url"),
+  mime_type: varchar("mime_type"),
+  size_bytes: integer("size_bytes"),
+  created_by: uuid("created_by").references(() => profiles.id),
+});
+
+export const discussions_post = pgTable("discussion_posts", {
+  id: serial("id").primaryKey(),
+  module_id: integer("module_id").references(() => modules.id),
+  cohort_id: integer("cohort_id").references(() => cohorts.id),
+  author_id: uuid("author_id").references(() => profiles.id),
+  parent_post_id: integer("parent_post_id").references(
+    (): AnyPgColumn => discussions_post.id,
+  ),
+  body: text("body"),
+  created_at: timestamp("created_at"),
+  edited_at: timestamp("edited_at"),
+});


### PR DESCRIPTION
Finished Issue #33: Build Admin Select Cohort Page After Login

- Added a name column to the cohorts table in schema.ts.
- Added 3 new tRPC procedures in routers/cohorts.ts: getAllCohorts, which is admin only and returns member_count and recent_logins, setActiveStatus, which is an admin only toggle of is_active, and deleteCohort, which is admin only and deletes a cohort.
- Made a component for the cohort lines in the page contained in CohortRow.tsx, which uses the last two tRPC procedures listed above.
- cohorts.tsx is the actual page that lists all cohorts via getAllCohorts and has a "Create New Cohort" button.